### PR TITLE
add Salsa20 and ChaCha constants

### DIFF
--- a/idapython_tools/findcrypt/consts.py
+++ b/idapython_tools/findcrypt/consts.py
@@ -2082,6 +2082,14 @@ non_sparse_consts = [
                 0x1948C25C, 0x02FB8A8C, 0x01C36AE4, 0xD6EBE1F9,
                 0x90D4F869, 0xA65CDEA0, 0x3F09252D, 0xC208E69F,
                 0xB74E6132, 0xCE77E25B, 0x578FDFE3, 0x3AC372E6 ]},
+    {"algorithm": "Salsa20_ChaCha",
+     "name": "Salsa20_ChaCha_sigma",
+     "size": "B",
+     "array": [ 101, 120, 112, 97, 110, 100, 32, 51, 50, 45, 98, 121, 116, 101, 32, 107 ]},
+    {"algorithm": "Salsa20_ChaCha",
+     "name": "Salsa20_ChaCha_tau",
+     "size": "B",
+     "array": [ 101, 120, 112, 97, 110, 100, 32, 49, 54, 45, 98, 121, 116, 101, 32, 107 ]},
 ]
 
 '''


### PR DESCRIPTION
Add Salsa20 and ChaCha constants.

- sigma: "expand 32-byte k"  
- tau: "expand 16-byte k"

Salsa20: [https://cr.yp.to/snuffle/salsa20/merged/salsa20.c](https://cr.yp.to/snuffle/salsa20/merged/salsa20.c)  
ChaCha: [https://cr.yp.to/streamciphers/timings/estreambench/submissions/salsa20/chacha8/ref/chacha.c](https://cr.yp.to/streamciphers/timings/estreambench/submissions/salsa20/chacha8/ref/chacha.c)  