### PR TITLE
Supported IDA 9.0 for findcrypt.py and findguid.py

### DIFF
--- a/idapython_tools/findcrypt/findcrypt.py
+++ b/idapython_tools/findcrypt/findcrypt.py
@@ -1,5 +1,5 @@
 import struct, copy
-import idc, idautils, ida_name, ida_bytes, ida_ua
+import idc, idautils, ida_name, ida_bytes, ida_ua, ida_search
 from consts import non_sparse_consts, sparse_consts, operand_consts
 
 if 'g_fc_prefix_cmt' not in globals():
@@ -109,7 +109,7 @@ def main():
                     if insn.ops[i].type == ida_ua.o_imm:
                         imm_operands.append(insn.ops[i].value)
                 if len(imm_operands) == 0:
-                    ea = idc.find_code(ea, idc.SEARCH_DOWN)
+                    ea = idc.find_code(ea, ida_search.SEARCH_DOWN)
                     continue
                 for const in operand_consts:
                     if const["value"] in imm_operands:
@@ -120,7 +120,7 @@ def main():
                         else:
                             idc.set_cmt(ea, g_fc_prefix_cmt + const["name"], 0)
                         break
-                ea = idc.find_code(ea, idc.SEARCH_DOWN)
+                ea = idc.find_code(ea, ida_search.SEARCH_DOWN)
     print("[*] finished")
 
 if __name__ == '__main__':

--- a/idapython_tools/findguid/findguid.py
+++ b/idapython_tools/findguid/findguid.py
@@ -1,5 +1,40 @@
-import idc, idaapi, ida_search, ida_name, ida_struct, ida_bytes
+import idc, idaapi, ida_search, ida_name, ida_bytes, ida_pro
 import os, binascii, struct
+
+try:
+    import ida_struct
+    add_struc = ida_struct.add_struc
+    get_struc_id = ida_struct.get_struc_id
+    add_struc_member = ida_struct.add_struc_member
+    get_struc_size = ida_struct.get_struc_size
+    get_struc = ida_struct.get_struc
+    get_member_by_name = ida_struct.get_member_by_name
+except ModuleNotFoundError:
+    # from IDA 9.0, many of them are in idc.
+    add_struc = idc.add_struc
+    get_struc_id = idc.get_struc_id
+    add_struc_member = idc.add_struc_member
+    get_struc_size = idc.get_struc_size
+    
+    # for IDA 9.0
+    # Some of them are needed to implement.
+    def get_struc(struct_tid):
+        tif = ida_typeinf.tinfo_t()
+        if tif.get_type_by_tid(struct_tid):
+            if tif.is_struct():
+                return tif
+        return ida_idapi.BADADDR
+    
+    def get_member_by_name(tif, name):
+        if not tif.is_struct():
+            return None
+    
+        udm = ida_typeinf.udm_t()
+        udm.name = name
+        idx = tif.find_udm(udm, ida_typeinf.STRMEM_NAME)
+        if idx != -1:
+            return udm
+        return None
 
 GUID_LIST_DIR = os.path.join(os.path.dirname(__file__), 'guid_list')
 GUID_LIST= []
@@ -10,15 +45,15 @@ GUID_LIST.append(['Folder ID', 'FOLDERID_', os.path.join(GUID_LIST_DIR, 'folder.
 GUID_LIST.append(['Media Type', '', os.path.join(GUID_LIST_DIR, 'media.txt')])
 
 def get_guid_tid():
-    tid = ida_struct.get_struc_id('GUID')
+    tid = get_struc_id('GUID')
     if tid == idaapi.BADADDR:
         print("[*] create GUID struct")
-        tid = ida_struct.add_struc(0xffffffff, 'GUID', 0)
-        sptr = ida_struct.get_struc(tid)
-        ida_struct.add_struc_member(sptr, 'Data1', 0x0, 0x20000000, None, 4)
-        ida_struct.add_struc_member(sptr, 'Data2', 0x4, 0x10000000, None, 2)
-        ida_struct.add_struc_member(sptr, 'Data3', 0x6, 0x10000000, None, 2)
-        ida_struct.add_struc_member(sptr, 'Data4', 0x8, 0x00000000, None, 8)
+        tid = add_struc(0xffffffff, 'GUID', 0)
+        sptr = get_struc(tid)
+        add_struc_member(sptr, 'Data1', 0x0, 0x20000000, None, 4)
+        add_struc_member(sptr, 'Data2', 0x4, 0x10000000, None, 2)
+        add_struc_member(sptr, 'Data3', 0x6, 0x10000000, None, 2)
+        add_struc_member(sptr, 'Data4', 0x8, 0x00000000, None, 8)
     return tid
 
 def make_binary_pattern(guid):
@@ -49,12 +84,15 @@ def main():
 
             ea = 0
             while True:
-                ea = idc.find_binary(ea, ida_search.SEARCH_DOWN | ida_search.SEARCH_NEXT | ida_search.SEARCH_NOSHOW, binary_pattern)
+                if ida_pro.IDA_SDK_VERSION >= 900:
+                    ea = ida_bytes.find_bytes(binary_pattern, ea, flags=ida_bytes.BIN_SEARCH_FORWARD | ida_bytes.BIN_SEARCH_NOSHOW)
+                else:
+                    ea = idc.find_binary(ea, ida_search.SEARCH_DOWN | ida_search.SEARCH_NEXT | ida_search.SEARCH_NOSHOW, binary_pattern)
                 if ea == idaapi.BADADDR:
                     break
 
                 idc.del_items(ea, 16, 0)
-                ida_bytes.create_struct(ea, ida_struct.get_struc_size(tid), tid)
+                ida_bytes.create_struct(ea, get_struc_size(tid), tid)
                 if idc.set_name(ea, guid_name, ida_name.SN_NOWARN) != 1:
                     for i in range(0, 100):
                         if idc.set_name(ea, guid_name + "_" + str(i), ida_name.SN_NOWARN) == 1:
@@ -62,6 +100,10 @@ def main():
                     else:
                         print("[!] 0x{:X}: failed to apply {}".format(ea, guid_name))
                 print("[*] 0x{:X}: {}".format(ea, guid_name))
+                
+                # add a byte size for find_bytes because it does not have SEARCH_NEXT option like find_binary
+                if ida_pro.IDA_SDK_VERSION >= 900:
+                    ea += 1
 
     print("[*] finished")
 


### PR DESCRIPTION
- findcrypt.py
Since IDA 9.0 has removed SEARCH_* from idc, changed to use ida_search instead.
- fincguid.py
Since IDA 9.0 has removed ida_struct and find_binary on both idc and ida_search, changed the code.
